### PR TITLE
add buildtool depend on pkg-config

### DIFF
--- a/kinesis_manager/package.xml
+++ b/kinesis_manager/package.xml
@@ -12,6 +12,7 @@
 
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>aws_common</depend>
   <depend>curl</depend>


### PR DESCRIPTION

Resolves:
15:41:49 CMake Error at /usr/share/cmake-3.5/Modules/FindPackageHandleStandardArgs.cmake:148 (message):
15:41:49   Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)

from: http://build.ros.org/view/Ksrc_uX/job/Kbin_uX64__kinesis_manager__ubuntu_xenial_amd64__binary/1/console


rosdep key `pkg-config` https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml#L4205

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
