### PR TITLE
add missing dependency on boost

### DIFF
--- a/kinesis_manager/package.xml
+++ b/kinesis_manager/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>aws_common</depend>
+  <depend>boost</depend>
   <depend>curl</depend>
   <depend>libssl-dev</depend>
   <test_depend>gtest</test_depend>


### PR DESCRIPTION
From: http://build.ros.org/view/Kbin_uX64/job/Kbin_uX64__kinesis_manager__ubuntu_xenial_amd64__binary/3/console

```
00:00:48.260 [ 83%] Building CXX object CMakeFiles/kinesis_manager.dir/src/kinesis_stream_manager.cpp.o
00:00:48.261 /usr/lib/ccache/x86_64-linux-gnu-g++   -DPLATFORM_LINUX -Dkinesis_manager_EXPORTS -isystem /opt/ros/kinetic/share/aws_common/cmake/../../../include -I/opt/ros/kinetic/include -I/tmp/binarydeb/ros-kinetic-kinesis-manager-1.0.0/obj-x86_64-linux-gnu/external/include -I/tmp/binarydeb/ros-kinetic-kinesis-manager-1.0.0/include  -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2  -fPIC -std=c++14  -fPIC   -o CMakeFiles/kinesis_manager.dir/src/kinesis_stream_manager.cpp.o -c /tmp/binarydeb/ros-kinetic-kinesis-manager-1.0.0/src/kinesis_stream_manager.cpp
00:00:48.542 In file included from /tmp/binarydeb/ros-kinetic-kinesis-manager-1.0.0/include/kinesis_manager/kinesis_stream_manager.h:26:0,
00:00:48.542                  from /tmp/binarydeb/ros-kinetic-kinesis-manager-1.0.0/src/kinesis_stream_manager.cpp:23:
00:00:48.542 /tmp/binarydeb/ros-kinetic-kinesis-manager-1.0.0/include/kinesis_manager/stream_subscription_installer.h:19:30: fatal error: boost/function.hpp: No such file or directory
00:00:48.542 compilation terminated.
```




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
