### PR TITLE
Improve unit tests coverage

### DIFF
--- a/kinesis_manager/CMakeLists.txt
+++ b/kinesis_manager/CMakeLists.txt
@@ -20,7 +20,9 @@ add_subdirectory(kvssdk)
 ## Library ##
 #############
 ## Declare a C++ library
-add_library(${PROJECT_NAME} SHARED src/stream_definition_provider.cpp src/kinesis_stream_manager.cpp src/default_callbacks.cpp)
+add_library(${PROJECT_NAME} SHARED src/stream_definition_provider.cpp 
+  src/kinesis_stream_manager.cpp src/default_callbacks.cpp
+  src/kinesis_video_stream_interface.cpp src/kinesis_video_producer_interface.cpp)
 set(${PROJECT_NAME}_IMPORTED_LIBRARIES producer log4cplus)
 add_dependencies(${PROJECT_NAME} KVS_SDK_IMPORT)
 
@@ -58,20 +60,38 @@ find_package(GTest QUIET)
 if(NOT GTEST_FOUND)
   message(WARNING "Could not find GTest. Not building unit tests.")
 else()
+  include_directories(/usr/include/gmock /usr/src/gmock)
+  add_library(libgmock /usr/src/gmock/src/gmock-all.cc)
+
   add_executable(test_kinesis_manager test/kinesis_manager_test.cpp)
   target_include_directories(test_kinesis_manager PRIVATE ${aws_common_INCLUDE_DIRS} ${KVSSDK_EXTERNAL_INCLUDE_DIR})
-
   target_link_libraries(test_kinesis_manager
-        ${GTEST_LIBRARIES}
-        pthread
-        ${aws_common_LIBRARIES}
-        ${PROJECT_NAME}
-        ${rclcpp_LIBRARIES}
-        ${PRODUCER_LIBRARY}
-        ${LOG_LIBRARY}
-        ${CURL_LIBRARIES}
+    ${PROJECT_NAME}
+    ${aws_common_LIBRARIES}
+    ${GTEST_LIBRARIES}
+    libgmock
+    pthread        
   )
   add_test(NAME test_kinesis_manager COMMAND test_kinesis_manager --gtest_output=xml:test_results/)
+
+  add_executable(test_stream_subscription_installer test/stream_subscription_installer_test.cpp)
+  target_include_directories(test_stream_subscription_installer PRIVATE ${aws_common_INCLUDE_DIRS} ${KVSSDK_EXTERNAL_INCLUDE_DIR})
+  target_link_libraries(test_stream_subscription_installer
+    ${PROJECT_NAME}
+    ${GTEST_LIBRARIES}
+    pthread
+  )
+  add_test(NAME test_stream_subscription_installer COMMAND test_stream_subscription_installer --gtest_output=xml:test_results/)
+
+  add_executable(test_default_callbacks test/default_callbacks_test.cpp)
+  target_include_directories(test_default_callbacks PRIVATE ${aws_common_INCLUDE_DIRS} ${KVSSDK_EXTERNAL_INCLUDE_DIR})
+  target_link_libraries(test_default_callbacks
+    ${PROJECT_NAME}
+    ${aws_common_LIBRARIES}
+    ${GTEST_LIBRARIES}
+    pthread
+  )
+  add_test(NAME test_default_callbacks COMMAND test_default_callbacks --gtest_output=xml:test_results/)
 endif()
 
 #############

--- a/kinesis_manager/include/kinesis_manager/kinesis_stream_manager.h
+++ b/kinesis_manager/include/kinesis_manager/kinesis_stream_manager.h
@@ -24,7 +24,7 @@
 #include <kinesis_manager/kinesis_client_facade.h>
 #include <kinesis_manager/stream_definition_provider.h>
 #include <kinesis_manager/stream_subscription_installer.h>
-
+#include <kinesis_manager/kinesis_video_producer_interface.h>
 
 namespace Aws {
 namespace Kinesis {
@@ -79,6 +79,15 @@ public:
     subscription_installer_(subscription_installer){};
   KinesisStreamManagerInterface() = default;
   virtual ~KinesisStreamManagerInterface() = default;
+
+  using VideoProducerFactory = std::function<unique_ptr<KinesisVideoProducerInterface>(
+    std::string, 
+    unique_ptr<com::amazonaws::kinesis::video::DeviceInfoProvider>,
+    unique_ptr<com::amazonaws::kinesis::video::ClientCallbackProvider>,
+    unique_ptr<com::amazonaws::kinesis::video::StreamCallbackProvider>,
+    unique_ptr<com::amazonaws::kinesis::video::CredentialProvider>
+  )>;
+
   /**
    * Initializes the video producer with the given callbacks.
    * @note This function must be called if the KinesisStreamManager is to be used for video streams.
@@ -88,21 +97,25 @@ public:
    * @param client_callback_provider
    * @param stream_callback_provider
    * @param credential_provider
+   * @param video_producer_factory
    * @return KinesisManagerStatus
    */
   virtual KinesisManagerStatus InitializeVideoProducer(std::string region,
     unique_ptr<com::amazonaws::kinesis::video::DeviceInfoProvider> device_info_provider,
     unique_ptr<com::amazonaws::kinesis::video::ClientCallbackProvider> client_callback_provider,
     unique_ptr<com::amazonaws::kinesis::video::StreamCallbackProvider> stream_callback_provider,
-    unique_ptr<com::amazonaws::kinesis::video::CredentialProvider> credential_provider) = 0;
+    unique_ptr<com::amazonaws::kinesis::video::CredentialProvider> credential_provider, 
+    VideoProducerFactory video_producer_factory = KinesisStreamManagerInterface::CreateDefaultVideoProducer) = 0;
 
   /**
    * Initializes the video producer using the default callbacks provided as part of the Kinesis
    * Manager package.
    * @param region
+   * @param video_producer_factory
    * @return KinesisManagerStatus
    */
-  virtual KinesisManagerStatus InitializeVideoProducer(std::string region) = 0;
+  virtual KinesisManagerStatus InitializeVideoProducer(std::string region,
+    VideoProducerFactory video_producer_factory = KinesisStreamManagerInterface::CreateDefaultVideoProducer) = 0;
 
   /**
    * Initializes a video stream using the given stream definition.
@@ -130,8 +143,8 @@ public:
    * @note Both the video producer and the given stream must have been initialized before any calls
    * to this function are made.
    * @param stream_name
-   * @param names list of names of the metadata items
-   * @param values list of values of the metadata items
+   * @param name the metadata name
+   * @param value the metadata value
    * @return KinesisManagerStatus
    */
   virtual KinesisManagerStatus PutMetadata(std::string stream_name, const std::string & name,
@@ -165,6 +178,13 @@ public:
    */
   virtual KinesisManagerStatus FetchRekognitionResults(const std::string & stream_name,
                                                        Aws::Vector<Model::Record> * records) = 0;
+
+  static unique_ptr<KinesisVideoProducerInterface> CreateDefaultVideoProducer(
+    std::string region,
+    unique_ptr<com::amazonaws::kinesis::video::DeviceInfoProvider> device_info_provider,
+    unique_ptr<com::amazonaws::kinesis::video::ClientCallbackProvider> client_callback_provider,
+    unique_ptr<com::amazonaws::kinesis::video::StreamCallbackProvider> stream_callback_provider,
+    unique_ptr<com::amazonaws::kinesis::video::CredentialProvider> credential_provider);
 
 protected:
   /**
@@ -234,8 +254,10 @@ public:
     unique_ptr<com::amazonaws::kinesis::video::DeviceInfoProvider> device_info_provider,
     unique_ptr<com::amazonaws::kinesis::video::ClientCallbackProvider> client_callback_provider,
     unique_ptr<com::amazonaws::kinesis::video::StreamCallbackProvider> stream_callback_provider,
-    unique_ptr<com::amazonaws::kinesis::video::CredentialProvider> credential_provider) override;
-  KinesisManagerStatus InitializeVideoProducer(std::string region) override;
+    unique_ptr<com::amazonaws::kinesis::video::CredentialProvider> credential_provider, 
+    KinesisStreamManagerInterface::VideoProducerFactory video_producer_factory = KinesisStreamManagerInterface::CreateDefaultVideoProducer) override;
+  KinesisManagerStatus InitializeVideoProducer(std::string region,
+    KinesisStreamManagerInterface::VideoProducerFactory video_producer_factory = KinesisStreamManagerInterface::CreateDefaultVideoProducer) override;
 
   KinesisManagerStatus InitializeVideoStream(
     unique_ptr<com::amazonaws::kinesis::video::StreamDefinition> stream_definition) override;
@@ -267,7 +289,7 @@ public:
   KinesisManagerStatus FetchRekognitionResults(const std::string & stream_name,
                                                Aws::Vector<Model::Record> * records) override;
 
-  com::amazonaws::kinesis::video::KinesisVideoProducer * get_video_producer()
+  KinesisVideoProducerInterface * get_video_producer()
   {
     return video_producer_.get();
   }
@@ -285,9 +307,9 @@ private:
    */
   KinesisManagerStatus UpdateShardIterator(const std::string & stream_name);
 
-  std::map<std::string, shared_ptr<com::amazonaws::kinesis::video::KinesisVideoStream>> video_streams_;
+  std::map<std::string, shared_ptr<KinesisVideoStreamInterface>> video_streams_;
   std::map<std::string, std::vector<uint8_t>> video_streams_codec_data_;
-  unique_ptr<com::amazonaws::kinesis::video::KinesisVideoProducer> video_producer_;
+  unique_ptr<KinesisVideoProducerInterface> video_producer_;
   unique_ptr<KinesisClient> kinesis_client_;
 
   struct RekognitionStreamInfo

--- a/kinesis_manager/include/kinesis_manager/kinesis_video_producer_interface.h
+++ b/kinesis_manager/include/kinesis_manager/kinesis_video_producer_interface.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <kinesis_manager/kinesis_video_stream_interface.h>
+#include <kinesis-video-producer/KinesisVideoProducer.h>
+
+namespace Aws {
+namespace Kinesis {
+
+class KinesisVideoProducerInterface
+{
+public:
+  
+  /**
+   * Create a video stream
+   * @param stream_definition A unique pointer to the StreamDefinition which describes the
+   *                          stream to be created.
+   * @return An KinesisVideoStream instance which is ready to start streaming.
+   */
+  virtual std::shared_ptr<KinesisVideoStreamInterface> CreateStreamSync(
+    std::unique_ptr<com::amazonaws::kinesis::video::StreamDefinition> stream_definition) = 0;
+
+  /**
+   * Frees the stream and removes it from the producer stream list.
+   *
+   * NOTE: This is a prompt operation and will stop the stream immediately without
+   * emptying the buffer.
+   *
+   * @param KinesisVideo_stream A unique pointer to the KinesisVideoStream to free and remove.
+   */
+  virtual void FreeStream(
+    std::shared_ptr<KinesisVideoStreamInterface> kinesis_video_stream) = 0;
+
+  virtual ~KinesisVideoProducerInterface(){};
+};
+
+class KinesisVideoProducerImpl : public KinesisVideoProducerInterface
+{
+public:
+  KinesisVideoProducerImpl(std::unique_ptr<com::amazonaws::kinesis::video::KinesisVideoProducer> video_producer)
+  : video_producer_(std::move(video_producer)){};
+
+  virtual std::shared_ptr<KinesisVideoStreamInterface> CreateStreamSync(
+    std::unique_ptr<com::amazonaws::kinesis::video::StreamDefinition> stream_definition) override;
+
+  virtual void FreeStream(
+    std::shared_ptr<KinesisVideoStreamInterface> kinesis_video_stream) override;
+
+private:
+  std::unique_ptr<com::amazonaws::kinesis::video::KinesisVideoProducer> video_producer_;
+};
+
+
+}  // namespace Kinesis
+}  // namespace Aws

--- a/kinesis_manager/include/kinesis_manager/kinesis_video_stream_interface.h
+++ b/kinesis_manager/include/kinesis_manager/kinesis_video_stream_interface.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#pragma once
+
+#include <kinesis-video-producer/KinesisVideoStream.h>
+
+namespace Aws {
+namespace Kinesis {
+
+class KinesisVideoStreamInterface
+{
+public:
+  /**
+   * @return true if the stream is ready, false otherwise.
+   */
+  virtual bool IsReady() const = 0;
+
+  /**
+   * Stops the the stream. Consecutive calls will fail until start is called again.
+   *
+   * NOTE: The function is async and will return immediately but the stream buffer
+   * will continue emptying until it's finished and the close stream will be called.
+   */
+  virtual bool Stop() = 0;
+
+  /**
+   * Packages and streams the frame to Kinesis Video service.
+   *
+   * @param frame The frame to be packaged and streamed.
+   * @return true if the encoder accepted the frame and false otherwise.
+   */
+  virtual bool PutFrame(com::amazonaws::kinesis::video::KinesisVideoFrame frame) const = 0;
+
+  /**
+   * Appends a "metadata" - a key/value string pair into the stream.
+   *
+   * NOTE: The metadata is modeled as MKV tags and are not immediately put into the stream as
+   * it might break the fragment.
+   * This is a limitation of MKV format as Tags are level 1 elements.
+   * Instead, they will be accumulated and inserted in-between the fragments and at the end of the stream.
+   * @param 1 name - the metadata name.
+   * @param 2 value - the metadata value.
+   * @param 3 persistent - whether the metadata is persistent.
+   *
+   */
+  virtual bool PutFragmentMetadata(const std::string& name, 
+    const std::string& value, bool persistent = true) = 0;
+
+  virtual std::shared_ptr<com::amazonaws::kinesis::video::KinesisVideoStream> 
+    GetKinesisVideoStream() {
+      return nullptr;
+    };
+
+  virtual ~KinesisVideoStreamInterface() {};
+};
+
+class KinesisVideoStreamImpl : public KinesisVideoStreamInterface
+{
+public:
+  KinesisVideoStreamImpl(
+    std::shared_ptr<com::amazonaws::kinesis::video::KinesisVideoStream> video_stream)
+  : video_stream_(video_stream){};
+
+  virtual bool IsReady() const override;
+  virtual bool Stop() override;
+  virtual bool PutFrame(com::amazonaws::kinesis::video::KinesisVideoFrame frame) const override;
+  virtual bool PutFragmentMetadata(const std::string& name, 
+    const std::string& value, bool persistent = true) override;
+  virtual std::shared_ptr<com::amazonaws::kinesis::video::KinesisVideoStream> 
+    GetKinesisVideoStream() override;
+
+private:
+  std::shared_ptr<com::amazonaws::kinesis::video::KinesisVideoStream> video_stream_;
+};
+
+}  // namespace Kinesis
+}  // namespace Aws

--- a/kinesis_manager/src/kinesis_video_producer_interface.cpp
+++ b/kinesis_manager/src/kinesis_video_producer_interface.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <kinesis_manager/kinesis_video_producer_interface.h>
+
+namespace Aws {
+namespace Kinesis {
+
+std::shared_ptr<KinesisVideoStreamInterface> KinesisVideoProducerImpl::CreateStreamSync(
+    std::unique_ptr<com::amazonaws::kinesis::video::StreamDefinition> stream_definition)
+{
+  auto video_stream = video_producer_->createStreamSync(std::move(stream_definition));
+  return std::make_shared<KinesisVideoStreamImpl>(video_stream);
+}
+
+void KinesisVideoProducerImpl::FreeStream(
+    std::shared_ptr<KinesisVideoStreamInterface> kinesis_video_stream)
+{
+  auto video_stream = kinesis_video_stream->GetKinesisVideoStream();
+  if (nullptr != video_stream) {
+    video_producer_->freeStream(video_stream);
+  }
+}
+
+}  // namespace Kinesis
+}  // namespace Aws

--- a/kinesis_manager/src/kinesis_video_stream_interface.cpp
+++ b/kinesis_manager/src/kinesis_video_stream_interface.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <kinesis_manager/kinesis_video_stream_interface.h>
+
+namespace Aws {
+namespace Kinesis {
+
+bool KinesisVideoStreamImpl::IsReady() const  
+{
+  return video_stream_->isReady();
+}
+
+bool KinesisVideoStreamImpl::Stop()
+{
+  return video_stream_->stop(); 
+}
+
+bool KinesisVideoStreamImpl::PutFrame(
+  com::amazonaws::kinesis::video::KinesisVideoFrame frame) const
+{
+  return video_stream_->putFrame(frame);
+}
+
+bool KinesisVideoStreamImpl::PutFragmentMetadata(const std::string& name, 
+        const std::string& value, bool persistent)
+{
+  return video_stream_->putFragmentMetadata(name, value, persistent);
+}
+
+std::shared_ptr<com::amazonaws::kinesis::video::KinesisVideoStream> 
+  KinesisVideoStreamImpl::GetKinesisVideoStream()
+{
+  return video_stream_;
+}
+
+}  // namespace Kinesis
+}  // namespace Aws

--- a/kinesis_manager/test/default_callbacks_test.cpp
+++ b/kinesis_manager/test/default_callbacks_test.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <kinesis_manager/default_callbacks.h>
+#include <gtest/gtest.h>
+
+using namespace Aws::Kinesis;
+
+TEST(ClientCallbackProviderSuite, defaultClientCallbackProviderTest)
+{
+  Aws::Kinesis::DefaultClientCallbackProvider test_subject;
+  UINT64 custom_handle;
+  UINT64 remaining_bytes;
+
+  EXPECT_EQ(test_subject.storageOverflowPressure(custom_handle, remaining_bytes), 
+    test_subject.getStorageOverflowPressureCallback()(custom_handle, remaining_bytes));
+  EXPECT_EQ(STATUS_SUCCESS, 
+    test_subject.storageOverflowPressure(custom_handle, remaining_bytes));
+}
+
+TEST(ClientCallbackProviderSuite, defaultStreamCallbackProviderTest)
+{
+  DefaultStreamCallbackProvider test_subject;
+  UINT64 custom_data;
+  STREAM_HANDLE stream_handle;
+  UINT64 last_buffering_ack;
+  UINT64 errored_timecode;
+  STATUS status_code;
+  UINT64 dropped_frame_timecode;
+
+  EXPECT_EQ(STATUS_SUCCESS,
+    test_subject.getStreamConnectionStaleCallback()(custom_data, stream_handle, last_buffering_ack));
+  EXPECT_EQ(STATUS_SUCCESS,
+    test_subject.getStreamErrorReportCallback()(custom_data, stream_handle, errored_timecode, status_code));
+  EXPECT_EQ(STATUS_SUCCESS,
+    test_subject.getDroppedFrameReportCallback()(custom_data, stream_handle, dropped_frame_timecode));
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/kinesis_manager/test/stream_subscription_installer_test.cpp
+++ b/kinesis_manager/test/stream_subscription_installer_test.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <kinesis_manager/stream_subscription_installer.h>
+#include <gtest/gtest.h>
+
+using namespace Aws::Kinesis;
+
+class TestStreamSubscriptionInstaller : public StreamSubscriptionInstaller
+{
+public:
+  void Uninstall(const std::string & topic_name) override {}
+  void PutInstaller(KinesisStreamInputType input_type, const SubscriberSetupFn& setup_fun) 
+  {
+    installers_.insert({input_type, setup_fun});
+  }
+};
+
+TEST(StreamSubscriptionInstallerSuite, streamSubscriptionInstallerTest)
+{
+  TestStreamSubscriptionInstaller test_subject;
+
+  KinesisStreamInputType input_type;
+  StreamSubscriptionDescriptor descriptor{input_type, std::string("topic_name"),
+    std::string("stream_name"), 10,
+    std::string("rekognition_topic_name"), std::string("rekognition_data_stream")
+  };
+
+  StreamSubscriptionDescriptor incomplete_descriptor = descriptor;
+  incomplete_descriptor.topic_name = "";
+  auto status = test_subject.Install(incomplete_descriptor);
+  EXPECT_EQ(KINESIS_MANAGER_STATUS_INVALID_INPUT, status);
+
+  incomplete_descriptor = descriptor;
+  incomplete_descriptor.stream_name = "";
+  status = test_subject.Install(incomplete_descriptor);
+  EXPECT_EQ(KINESIS_MANAGER_STATUS_INVALID_INPUT, status);
+
+  status = test_subject.Install(descriptor);
+  EXPECT_EQ(KINESIS_MANAGER_STATUS_SUBSCRIPTION_INSTALLER_NOT_FOUND, status);
+
+  bool setup_called = false;
+  SubscriberSetupFn setup_fun = [&setup_called](const StreamSubscriptionDescriptor & descriptor) { 
+    setup_called = true;
+    return true; 
+  };
+  test_subject.PutInstaller(descriptor.input_type, setup_fun);
+  status = test_subject.Install(descriptor);
+  EXPECT_EQ(KINESIS_MANAGER_STATUS_SUCCESS, status);
+  EXPECT_TRUE(setup_called);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add unit tests to improve test coverage to 

```
Overall coverage rate:
  lines......: 91.7% (873 of 952 lines)
  functions..: 82.5% (226 of 274 functions)
  branches...: 32.9% (1379 of 4196 branches)
```

Google mock is used to tests run without AWS credentials. 

On the other hand, as some classes from `amazon-kinesis-video-streams-producer-sdk-cpp` don't have static methods, some refactor was performed in `kinesis_stream_manager.h` for being able to inject the mocks, using the techniques described in the [Google Test CookBook](https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md#mocking-nonvirtual-methods). Besides that, in this PR I've tried to make as little changes as possible to the production code. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
