### PR TITLE
get log4cplus sources from github instead of sourceforge

### DIFF
--- a/kinesis_manager/kvssdk/apply-kvs-patch
+++ b/kinesis_manager/kvssdk/apply-kvs-patch
@@ -1,3 +1,4 @@
 #!/bin/bash
 sed -i '/pkg_check_modules.*\(GLIB\|GST\|GOBJ\)/s/^/#/g' $1/CMakeLists.txt
 sed -i '/make\s\+\(start\|kinesis\)/s/^/#/g' $1/min-install-script
+sed -i 's/https:\/\/sourceforge.net\/projects\/log4cplus\/files\/log4cplus-stable\/1.2.0\/log4cplus-1.2.0.tar.xz/https:\/\/github.com\/log4cplus\/log4cplus\/releases\/download\/REL_1_2_0\/log4cplus-1.2.0.tar.xz/g' $1/min-install-script


### PR DESCRIPTION
*Description of changes:*

Building the KVS Producer SDK is failing, because downloading the `log4cplus` sources from SourceForge appears to be unreliable (frequently getting `curl: (35) gnutls_handshake() failed: Error in the push function` errors as of March 5th, 2019).

We believe that downloading from GitHub is more reliable, so this changes patches the install scripts to download the `log4cplus` sources from GitHub instead of SourceForge.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.