### PR TITLE
Always send notification emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
 - gcc
 notifications:
   email:
-    on_success: change
+    on_success: always
     on_failure: always
     recipients:
       - ros-contributions@amazon.com


### PR DESCRIPTION
This should make sure a success notification email is sent.
If we agree on this change we should apply it to all other repos too.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
