### PR TITLE
Link libraries only if test targets exist

### DIFF
--- a/kinesis_manager/CMakeLists.txt
+++ b/kinesis_manager/CMakeLists.txt
@@ -53,7 +53,8 @@ target_link_libraries(${PROJECT_NAME} ${AWSSDK_LIBS_TO_LINK} ${${PROJECT_NAME}_I
 ## Tests ##
 #############
 
-if(BUILD_TESTING OR CATKIN_ENABLE_TESTING)
+enable_testing()
+if($ENV{ROS_VERSION} STREQUAL "1" OR ($ENV{ROS_VERSION} STREQUAL "2" AND BUILD_TESTING))
   # Build tests which perform API calls to AWS and require user configuration set up
   if(BUILD_AWS_TESTING)
     add_definitions(-DBUILD_AWS_TESTING)

--- a/kinesis_manager/CMakeLists.txt
+++ b/kinesis_manager/CMakeLists.txt
@@ -53,55 +53,55 @@ target_link_libraries(${PROJECT_NAME} ${AWSSDK_LIBS_TO_LINK} ${${PROJECT_NAME}_I
 ## Tests ##
 #############
 
-enable_testing()
+if(BUILD_TESTING OR CATKIN_ENABLE_TESTING)
+  # Build tests which perform API calls to AWS and require user configuration set up
+  if(BUILD_AWS_TESTING)
+    add_definitions(-DBUILD_AWS_TESTING)
+  endif()
 
-# Build tests which perform API calls to AWS and require user configuration set up
-if(BUILD_AWS_TESTING)
-  add_definitions(-DBUILD_AWS_TESTING)
+  find_common_test_packages()
+
+  add_common_gtest(test_kinesis_manager
+    test/kinesis_manager_test.cpp
+  )
+  target_include_directories(test_kinesis_manager PRIVATE
+    ${aws_common_INCLUDE_DIRS}
+    ${KVSSDK_EXTERNAL_INCLUDE_DIR}
+  )
+  target_link_libraries(test_kinesis_manager
+    ${PROJECT_NAME}
+    ${aws_common_LIBRARIES}
+    ${GMOCK_LIBRARY}
+    pthread
+  )
+
+  add_common_gtest(test_stream_subscription_installer
+    test/stream_subscription_installer_test.cpp
+  )
+  target_include_directories(test_stream_subscription_installer PRIVATE
+    ${aws_common_INCLUDE_DIRS}
+    ${KVSSDK_EXTERNAL_INCLUDE_DIR}
+  )
+  target_link_libraries(test_stream_subscription_installer
+    ${PROJECT_NAME}
+    ${GMOCK_LIBRARY}
+    pthread
+  )
+
+  add_common_gtest(test_default_callbacks
+    test/default_callbacks_test.cpp
+  )
+  target_include_directories(test_default_callbacks PRIVATE
+    ${aws_common_INCLUDE_DIRS}
+    ${KVSSDK_EXTERNAL_INCLUDE_DIR}
+  )
+  target_link_libraries(test_default_callbacks
+    ${PROJECT_NAME}
+    ${aws_common_LIBRARIES}
+    ${GMOCK_LIBRARY}
+    pthread
+  )
 endif()
-
-find_common_test_packages()
-
-add_common_gtest(test_kinesis_manager
-  test/kinesis_manager_test.cpp
-)
-target_include_directories(test_kinesis_manager PRIVATE
-  ${aws_common_INCLUDE_DIRS}
-  ${KVSSDK_EXTERNAL_INCLUDE_DIR}
-)
-target_link_libraries(test_kinesis_manager
-  ${PROJECT_NAME}
-  ${aws_common_LIBRARIES}
-  ${GMOCK_LIBRARY}
-  pthread
-)
-
-add_common_gtest(test_stream_subscription_installer
-  test/stream_subscription_installer_test.cpp
-)
-target_include_directories(test_stream_subscription_installer PRIVATE
-  ${aws_common_INCLUDE_DIRS}
-  ${KVSSDK_EXTERNAL_INCLUDE_DIR}
-)
-target_link_libraries(test_stream_subscription_installer
-  ${PROJECT_NAME}
-  ${GMOCK_LIBRARY}
-  pthread
-)
-
-add_common_gtest(test_default_callbacks
-  test/default_callbacks_test.cpp
-)
-target_include_directories(test_default_callbacks PRIVATE
-  ${aws_common_INCLUDE_DIRS}
-  ${KVSSDK_EXTERNAL_INCLUDE_DIR}
-)
-target_link_libraries(test_default_callbacks
-  ${PROJECT_NAME}
-  ${aws_common_LIBRARIES}
-  ${GMOCK_LIBRARY}
-  pthread
-)
 
 
 #############

--- a/kinesis_manager/CMakeLists.txt
+++ b/kinesis_manager/CMakeLists.txt
@@ -54,17 +54,17 @@ target_link_libraries(${PROJECT_NAME} ${AWSSDK_LIBS_TO_LINK} ${${PROJECT_NAME}_I
 #############
 
 enable_testing()
-if($ENV{ROS_VERSION} STREQUAL "1" OR ($ENV{ROS_VERSION} STREQUAL "2" AND BUILD_TESTING))
-  # Build tests which perform API calls to AWS and require user configuration set up
-  if(BUILD_AWS_TESTING)
-    add_definitions(-DBUILD_AWS_TESTING)
-  endif()
+# Build tests which perform API calls to AWS and require user configuration set up
+if(BUILD_AWS_TESTING)
+  add_definitions(-DBUILD_AWS_TESTING)
+endif()
 
-  find_common_test_packages()
+find_common_test_packages()
 
-  add_common_gtest(test_kinesis_manager
-    test/kinesis_manager_test.cpp
-  )
+add_common_gtest(test_kinesis_manager
+  test/kinesis_manager_test.cpp
+)
+if(TARGET test_kinesis_manager)
   target_include_directories(test_kinesis_manager PRIVATE
     ${aws_common_INCLUDE_DIRS}
     ${KVSSDK_EXTERNAL_INCLUDE_DIR}
@@ -75,10 +75,12 @@ if($ENV{ROS_VERSION} STREQUAL "1" OR ($ENV{ROS_VERSION} STREQUAL "2" AND BUILD_T
     ${GMOCK_LIBRARY}
     pthread
   )
+endif()
 
-  add_common_gtest(test_stream_subscription_installer
-    test/stream_subscription_installer_test.cpp
-  )
+add_common_gtest(test_stream_subscription_installer
+  test/stream_subscription_installer_test.cpp
+)
+if(TARGET test_stream_subscription_installer)
   target_include_directories(test_stream_subscription_installer PRIVATE
     ${aws_common_INCLUDE_DIRS}
     ${KVSSDK_EXTERNAL_INCLUDE_DIR}
@@ -88,10 +90,12 @@ if($ENV{ROS_VERSION} STREQUAL "1" OR ($ENV{ROS_VERSION} STREQUAL "2" AND BUILD_T
     ${GMOCK_LIBRARY}
     pthread
   )
+endif()
 
-  add_common_gtest(test_default_callbacks
-    test/default_callbacks_test.cpp
-  )
+add_common_gtest(test_default_callbacks
+  test/default_callbacks_test.cpp
+)
+if(TARGET test_default_callbacks)
   target_include_directories(test_default_callbacks PRIVATE
     ${aws_common_INCLUDE_DIRS}
     ${KVSSDK_EXTERNAL_INCLUDE_DIR}
@@ -103,7 +107,6 @@ if($ENV{ROS_VERSION} STREQUAL "1" OR ($ENV{ROS_VERSION} STREQUAL "2" AND BUILD_T
     pthread
   )
 endif()
-
 
 #############
 ## Install ##

--- a/kinesis_manager/package.xml
+++ b/kinesis_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>kinesis_manager</name>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
   <description>AWS Kinesis stream management library intended for use with the Kinesis Video Producer SDK</description>
   <url>http://wiki.ros.org/kinesis_manager</url>
 


### PR DESCRIPTION
Checking if the target exists before using it (like we did in cloudwatch-common).
(I know there are multiple commits here - I'll squash)

ROS1Prerelease: https://travis-ci.org/AAlon/ROS1Prerelease/builds/582200175
ROS2Prerelease: https://travis-ci.org/AAlon/ROS2Prerelease/builds/582200215 (Pretty sure it passed. there might be a bug in ros-industrial that caused the last step - `colcon test-result` - to fail)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
