### PR TITLE
Erase codec private data when freeing stream

### DIFF
--- a/kinesis_manager/src/kinesis_stream_manager.cpp
+++ b/kinesis_manager/src/kinesis_stream_manager.cpp
@@ -318,6 +318,10 @@ void KinesisStreamManager::FreeStream(std::string stream_name)
     }
     video_producer_->FreeStream(video_streams_.at(stream_name));
     video_streams_.erase(stream_name);
+    // Erase stream's codec data
+    if (video_streams_codec_data_.count(stream_name) > 0) {
+      video_streams_codec_data_.erase(stream_name);
+    }
   }
 }
 


### PR DESCRIPTION
*Issue #, if available:*
In order to make possible to restart a stream its codec private data should be erased when freeing it.

*Description of changes:*
Erase codec private data when freeing it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
